### PR TITLE
feat: create packages folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,17 @@ dependencies = [
  "protoc-bin-vendored",
  "schemars",
  "serde",
+ "slinky_wasm",
  "thiserror",
+]
+
+[[package]]
+name = "slinky_wasm"
+version = "0.0.1"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Get oracle prices
 
 ```json
 {
-  "get_pricess": {
+  "get_prices": {
     "pair_ids": ["BITCOIN/USD"] // {Base}/{Quote}
   }
 }

--- a/packages/slinky_wasm/Cargo.toml
+++ b/packages/slinky_wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "slinky"
+name = "slinky_wasm"
 version = "0.0.1"
 authors = ["alapc"]
 edition = "2021"
@@ -20,14 +20,6 @@ library = []
 cosmwasm-std = { version = "1.5.0", features = ["stargate"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.23" }
-protobuf = "3.4.0"
-slinky_wasm = { path = "packages/slinky_wasm" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.5.0" }
-
-[build-dependencies]
-protobuf-codegen = "3.4"
-protoc-bin-vendored = "3"
-protobuf = { version = "3.4" }

--- a/packages/slinky_wasm/src/lib.rs
+++ b/packages/slinky_wasm/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod oracle;

--- a/packages/slinky_wasm/src/oracle.rs
+++ b/packages/slinky_wasm/src/oracle.rs
@@ -1,0 +1,52 @@
+// query response
+use cosmwasm_std::{Timestamp, Uint256};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct InstantiateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Foo {},
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    GetPrice { base: String, quote: String },
+    GetPrices { pair_ids: Vec<String> },
+    GetAllCurrencyPairs {},
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct GetPriceResponse {
+    pub price: QuotePrice,
+    pub nonce: u64,
+    pub decimals: u64,
+    pub id: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct GetPricesResponse {
+    pub prices: Vec<GetPriceResponse>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct QuotePrice {
+    pub price: Uint256,
+    pub block_timestamp: Timestamp,
+    pub block_height: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct GetAllCurrencyPairsResponse {
+    pub currency_pairs: Vec<CurrencyPairResponse>,
+}
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[allow(non_snake_case)]
+pub struct CurrencyPairResponse {
+    pub Base: String,
+    pub Quote: String,
+}

--- a/packages/slinky_wasm/src/oracle.rs
+++ b/packages/slinky_wasm/src/oracle.rs
@@ -15,7 +15,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetPrice { base: String, quote: String },
+    GetPrice { pair_id: String },
     GetPrices { pair_ids: Vec<String> },
     GetAllCurrencyPairs {},
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,62 +1,104 @@
 use std::str::FromStr;
 
-use cosmwasm_std::{to_json_binary, Binary, Deps, Empty, Env, QueryRequest, StdResult, Timestamp, Uint256};
+use cosmwasm_std::{to_json_binary, Binary, Deps, Empty, Env, QueryRequest, StdResult, Uint256};
 
-use crate::state::Contract;
 use crate::msgs::QueryMsg;
-use crate::slinky_oracle::{GetAllCurrencyPairsRequest, GetPricesRequest, GetPriceRequest, CurrencyPair};
+use crate::slinky_oracle::{
+    CurrencyPair, GetAllCurrencyPairsRequest, GetPriceRequest, GetPricesRequest,
+};
+use crate::state::Contract;
 use crate::timestamp::convert_iso_string_to_timestamp;
 use protobuf::{Message, MessageField};
+use slinky_wasm::oracle::{
+    GetAllCurrencyPairsResponse, GetPriceResponse, GetPricesResponse, QuotePrice,
+};
 
 impl<'a> Contract {
-    fn get_price(&self, deps: Deps, _env: Env, base: String, quote: String) -> StdResult<GetPriceResponse> {
-        let request = GetPriceRequest { 
-            currency_pair:MessageField::some(CurrencyPair{ Base: base, Quote: quote, special_fields: ::protobuf::SpecialFields::new() }),
-            special_fields: ::protobuf::SpecialFields::new()
+    fn get_price(
+        &self,
+        deps: Deps,
+        _env: Env,
+        base: String,
+        quote: String,
+    ) -> StdResult<GetPriceResponse> {
+        let request = GetPriceRequest {
+            currency_pair: MessageField::some(CurrencyPair {
+                Base: base,
+                Quote: quote,
+                special_fields: ::protobuf::SpecialFields::new(),
+            }),
+            special_fields: ::protobuf::SpecialFields::new(),
         };
         let bytes = request.write_to_bytes().unwrap();
-        
+
         let data = Binary::from(bytes);
-        let request = QueryRequest::Stargate{path: "/slinky.oracle.v1.Query/GetPrice".to_string(), data};
+        let request = QueryRequest::Stargate {
+            path: "/slinky.oracle.v1.Query/GetPrice".to_string(),
+            data,
+        };
         let res: GetPriceResponseRaw = deps.querier.query(&request)?;
         Ok(convert_raw_price_response(&res))
     }
 
-    fn get_prices(&self, deps: Deps, _env: Env, pair_ids: Vec<String>) -> StdResult<GetPricesResponse> {
-        let request = GetPricesRequest { 
+    fn get_prices(
+        &self,
+        deps: Deps,
+        _env: Env,
+        pair_ids: Vec<String>,
+    ) -> StdResult<GetPricesResponse> {
+        let request = GetPricesRequest {
             currency_pair_ids: pair_ids,
-            special_fields: ::protobuf::SpecialFields::new()
-        };
-        let bytes = request.write_to_bytes().unwrap();
-        
-        let data = Binary::from(bytes);
-        let request = QueryRequest::Stargate{path: "/slinky.oracle.v1.Query/GetPrices".to_string(), data};
-        let raw_res: GetPricesResponseRaw = deps.querier.query(&request)?;
-        let res = GetPricesResponse {
-            prices: raw_res.prices.into_iter().map(|raw| convert_raw_price_response(&raw)).collect()
-        };
-        Ok(res)
-    }
-    fn get_all_currency_pairs(&self, deps: Deps, _env: Env) -> StdResult<GetAllCurrencyPairsResponse> {
-        let request = GetAllCurrencyPairsRequest { 
-            special_fields: ::protobuf::SpecialFields::new()
+            special_fields: ::protobuf::SpecialFields::new(),
         };
         let bytes = request.write_to_bytes().unwrap();
 
         let data = Binary::from(bytes);
-        let request = QueryRequest::<Empty>::Stargate{path: "/slinky.oracle.v1.Query/GetAllCurrencyPairs".to_string(), data};
+        let request = QueryRequest::Stargate {
+            path: "/slinky.oracle.v1.Query/GetPrices".to_string(),
+            data,
+        };
+        let raw_res: GetPricesResponseRaw = deps.querier.query(&request)?;
+        let res = GetPricesResponse {
+            prices: raw_res
+                .prices
+                .into_iter()
+                .map(|raw| convert_raw_price_response(&raw))
+                .collect(),
+        };
+        Ok(res)
+    }
+    fn get_all_currency_pairs(
+        &self,
+        deps: Deps,
+        _env: Env,
+    ) -> StdResult<GetAllCurrencyPairsResponse> {
+        let request = GetAllCurrencyPairsRequest {
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        let bytes = request.write_to_bytes().unwrap();
+
+        let data = Binary::from(bytes);
+        let request = QueryRequest::<Empty>::Stargate {
+            path: "/slinky.oracle.v1.Query/GetAllCurrencyPairs".to_string(),
+            data,
+        };
         let res: GetAllCurrencyPairsResponse = deps.querier.query(&request)?;
         Ok(res)
     }
 }
 
-
 impl<'a> Contract {
     pub fn query(&self, deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         match msg {
-            QueryMsg::GetPrice { base, quote } => to_json_binary(&self.get_price(deps, env, base, quote)?),
-            QueryMsg::GetPrices { pair_ids } => to_json_binary(&self.get_prices(deps, env, pair_ids)?),
-            QueryMsg::GetAllCurrencyPairs {} => to_json_binary(&self.get_all_currency_pairs(deps, env)?),
+            QueryMsg::GetPrice { base, quote } => {
+                to_json_binary(&self.get_price(deps, env, base, quote)?)
+            }
+            QueryMsg::GetPrices { pair_ids } => {
+                to_json_binary(&self.get_prices(deps, env, pair_ids)?)
+            }
+            QueryMsg::GetAllCurrencyPairs {} => {
+                to_json_binary(&self.get_all_currency_pairs(deps, env)?)
+            }
         }
     }
 }
@@ -86,46 +128,12 @@ pub struct GetPriceResponseRaw {
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetPricesResponseRaw {
-    pub prices: Vec<GetPriceResponseRaw>
+    pub prices: Vec<GetPriceResponseRaw>,
 }
-
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct QuotePriceRaw {
     pub price: String,
     pub block_timestamp: String,
     pub block_height: String,
-}
-
-// query response
-
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GetPriceResponse {
-    pub price: QuotePrice,
-    pub nonce: u64,
-    pub decimals: u64,
-    pub id: u64,
-}
-
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GetPricesResponse {
-    pub prices: Vec<GetPriceResponse>
-}
-
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct QuotePrice {
-    pub price: Uint256,
-    pub block_timestamp: Timestamp,
-    pub block_height: u64,
-}
-
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GetAllCurrencyPairsResponse {
-    pub currency_pairs: Vec<CurrencyPairResponse>,
-}
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[allow(non_snake_case)]
-pub struct CurrencyPairResponse {
-    pub Base: String,
-    pub Quote: String,
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,9 +1,12 @@
 use std::str::FromStr;
 
 use cosmwasm_std::{to_json_binary, Binary, Deps, Empty, Env, QueryRequest, StdResult, Uint256};
+use slinky_wasm::oracle::{GetPriceResponse, GetPricesResponse, QuotePrice, GetAllCurrencyPairsResponse};
+
 
 use crate::msgs::QueryMsg;
 use crate::slinky_oracle::{GetAllCurrencyPairsRequest, GetPricesRequest, GetPriceRequest};
+use crate::state::Contract;
 use crate::timestamp::convert_iso_string_to_timestamp;
 use protobuf::Message;
 


### PR DESCRIPTION
The PR creates a `packages` folder for the Slinky contracts. This allows developers using Slinky price feeds on miniwasm minitias to easily copy the package folder and integrate the queries into their own contracts, rather than implementing the components themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new oracle module for smart contracts, enabling queries for price data and available currency pairs.
  * Added support for querying single and multiple price points, as well as retrieving all supported currency pairs.

* **Chores**
  * Added a new package dependency and manifest for the oracle module.

* **Refactor**
  * Removed duplicate response type definitions to streamline code and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->